### PR TITLE
Add parameter to optionally validate all keys on decrypt

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -590,6 +590,22 @@ in `/tmp/sops.sock` and not the local key service, you can run:
 
 `sops --enable-local-keyservice=false --keyservice unix:///tmp/sops.sock -d file.yaml`
 
+Validate Keys
+~~~~~~~~~~~~~
+
+Normally on decryption, SOPS will try each key service in turn, returning as soon
+as one has succeeded.
+There are times when it may be useful to validate that all keys from a particular
+key service are working. For example prior to or following significant infrastructure
+changes, or when cycling upstream keys.
+
+You can enable this behavior by passing in `--validate-key <keyservice>`.
+
+For example to ensure all KMS keys are validated you can run:
+
+`sops --decrypt --validate-key kms file.yml`
+
+
 Important information on types
 ------------------------------
 

--- a/cmd/sops/common/common.go
+++ b/cmd/sops/common/common.go
@@ -26,11 +26,13 @@ type DecryptTreeOpts struct {
 	IgnoreMac bool
 	// Cipher is the cryptographic cipher to use to decrypt the values inside the tree
 	Cipher sops.Cipher
+	// ValidateKeys will ensure that the object can be decrypted by all keys in that array, rather than by any available
+	ValidateKeys []string
 }
 
 // DecryptTree decrypts the tree passed in through the DecryptTreeOpts and additionally returns the decrypted data key
 func DecryptTree(opts DecryptTreeOpts) (dataKey []byte, err error) {
-	dataKey, err = opts.Tree.Metadata.GetDataKeyWithKeyServices(opts.KeyServices)
+	dataKey, err = opts.Tree.Metadata.GetDataKeyWithKeyServices(opts.KeyServices, opts.ValidateKeys)
 	if err != nil {
 		return nil, NewExitError(err, codes.CouldNotRetrieveKey)
 	}

--- a/cmd/sops/decrypt.go
+++ b/cmd/sops/decrypt.go
@@ -10,13 +10,14 @@ import (
 )
 
 type decryptOpts struct {
-	Cipher      sops.Cipher
-	InputStore  sops.Store
-	OutputStore sops.Store
-	InputPath   string
-	IgnoreMAC   bool
-	Extract     []interface{}
-	KeyServices []keyservice.KeyServiceClient
+	Cipher       sops.Cipher
+	InputStore   sops.Store
+	OutputStore  sops.Store
+	InputPath    string
+	IgnoreMAC    bool
+	Extract      []interface{}
+	KeyServices  []keyservice.KeyServiceClient
+	ValidateKeys []string
 }
 
 func decrypt(opts decryptOpts) (decryptedFile []byte, err error) {
@@ -26,10 +27,11 @@ func decrypt(opts decryptOpts) (decryptedFile []byte, err error) {
 	}
 
 	_, err = common.DecryptTree(common.DecryptTreeOpts{
-		Cipher:      opts.Cipher,
-		IgnoreMac:   opts.IgnoreMAC,
-		Tree:        tree,
-		KeyServices: opts.KeyServices,
+		Cipher:       opts.Cipher,
+		IgnoreMac:    opts.IgnoreMAC,
+		Tree:         tree,
+		KeyServices:  opts.KeyServices,
+		ValidateKeys: opts.ValidateKeys,
 	})
 	if err != nil {
 		return nil, err

--- a/cmd/sops/main.go
+++ b/cmd/sops/main.go
@@ -344,6 +344,10 @@ func main() {
 			Name:  "shamir-secret-sharing-threshold",
 			Usage: "the number of master keys required to retrieve the data key with shamir",
 		},
+		cli.StringSliceFlag{
+			Name:  "validate-key",
+			Usage: "used when decrypting. Comma separated list of key types e.g. --validate-key kms,gpg,gcp-kms",
+		},
 	}, keyserviceFlags...)
 
 	app.Action = func(c *cli.Context) error {
@@ -396,13 +400,14 @@ func main() {
 				return common.NewExitError(fmt.Errorf("error parsing --extract path: %s", err), codes.InvalidTreePathFormat)
 			}
 			output, err = decrypt(decryptOpts{
-				OutputStore: outputStore,
-				InputStore:  inputStore,
-				InputPath:   fileName,
-				Cipher:      aes.NewCipher(),
-				Extract:     extract,
-				KeyServices: svcs,
-				IgnoreMAC:   c.Bool("ignore-mac"),
+				OutputStore:  outputStore,
+				InputStore:   inputStore,
+				InputPath:    fileName,
+				Cipher:       aes.NewCipher(),
+				Extract:      extract,
+				KeyServices:  svcs,
+				IgnoreMAC:    c.Bool("ignore-mac"),
+				ValidateKeys: c.StringSlice("validate-key"),
 			})
 		}
 		if c.Bool("rotate") {
@@ -558,6 +563,7 @@ func keyservices(c *cli.Context) (svcs []keyservice.KeyServiceClient) {
 		if err != nil {
 			log.Fatalf("failed to listen: %v", err)
 		}
+
 		svcs = append(svcs, keyservice.NewKeyServiceClient(conn))
 	}
 	return

--- a/cmd/sops/subcommand/groups/add.go
+++ b/cmd/sops/subcommand/groups/add.go
@@ -25,7 +25,7 @@ func Add(opts AddOpts) error {
 	if err != nil {
 		return err
 	}
-	dataKey, err := tree.Metadata.GetDataKeyWithKeyServices(opts.KeyServices)
+	dataKey, err := tree.Metadata.GetDataKeyWithKeyServices(opts.KeyServices, nil)
 	if err != nil {
 		return err
 	}

--- a/cmd/sops/subcommand/groups/delete.go
+++ b/cmd/sops/subcommand/groups/delete.go
@@ -27,7 +27,7 @@ func Delete(opts DeleteOpts) error {
 	if err != nil {
 		return err
 	}
-	dataKey, err := tree.Metadata.GetDataKeyWithKeyServices(opts.KeyServices)
+	dataKey, err := tree.Metadata.GetDataKeyWithKeyServices(opts.KeyServices, nil)
 	if err != nil {
 		return err
 	}

--- a/cmd/sops/subcommand/updatekeys/updatekeys.go
+++ b/cmd/sops/subcommand/updatekeys/updatekeys.go
@@ -86,7 +86,7 @@ func updateFile(opts Opts) error {
 			return nil
 		}
 	}
-	key, err := tree.Metadata.GetDataKeyWithKeyServices(opts.KeyServices)
+	key, err := tree.Metadata.GetDataKeyWithKeyServices(opts.KeyServices, nil)
 	if err != nil {
 		return fmt.Errorf("error getting data key: %s", err)
 	}

--- a/sops.go
+++ b/sops.go
@@ -431,7 +431,7 @@ func (m *Metadata) UpdateMasterKeys(dataKey []byte) (errs []error) {
 
 // GetDataKeyWithKeyServices retrieves the data key, asking KeyServices to decrypt it with each
 // MasterKey in the Metadata's KeySources until one of them succeeds.
-func (m Metadata) GetDataKeyWithKeyServices(svcs []keyservice.KeyServiceClient) ([]byte, error) {
+func (m Metadata) GetDataKeyWithKeyServices(svcs []keyservice.KeyServiceClient, validateKeys []string) ([]byte, error) {
 	if m.DataKey != nil {
 		return m.DataKey, nil
 	}
@@ -441,8 +441,8 @@ func (m Metadata) GetDataKeyWithKeyServices(svcs []keyservice.KeyServiceClient) 
 	}
 	var parts [][]byte
 	for i, group := range m.KeyGroups {
-		part, err := decryptKeyGroup(group, svcs)
-		if err == nil {
+		part, err := decryptKeyGroup(group, svcs, validateKeys)
+		if part != nil {
 			parts = append(parts, part)
 		}
 		getDataKeyErr.GroupResults[i] = err
@@ -463,6 +463,9 @@ func (m Metadata) GetDataKeyWithKeyServices(svcs []keyservice.KeyServiceClient) 
 		}
 		dataKey = parts[0]
 	}
+	if len(validateKeys) >= 1 && getDataKeyErr.GroupResults[0] != nil {
+		log.Warn("At least one Key Service is unable to recover the Data Key: %s", getDataKeyErr.GroupResults)
+	}
 	log.Info("Data key recovered successfully")
 	m.DataKey = dataKey
 	return dataKey, nil
@@ -470,16 +473,42 @@ func (m Metadata) GetDataKeyWithKeyServices(svcs []keyservice.KeyServiceClient) 
 
 // decryptKeyGroup tries to decrypt the contents of the provided KeyGroup with
 // any of the MasterKeys in the KeyGroup with any of the provided key services,
-// returning as soon as one key service succeeds.
-func decryptKeyGroup(group KeyGroup, svcs []keyservice.KeyServiceClient) ([]byte, error) {
+// normally returning as soon as one key service succeeds.
+// However if validateKeys is set, it will ensure that all key services matching
+// the string(s) in the slice are validated against.
+func decryptKeyGroup(group KeyGroup, svcs []keyservice.KeyServiceClient, validateKeys []string) ([]byte, error) {
 	var keyErrs []error
+	var part []byte
 	for _, key := range group {
-		part, err := decryptKey(key, svcs)
+		if part != nil {
+			if len(validateKeys) == 0 {
+				return part, nil
+			}
+			var shouldValidate bool = false
+
+			for _, validateKey := range validateKeys {
+				if strings.Contains(key.ToString(), validateKey) {
+					shouldValidate = true
+				}
+			}
+			if !shouldValidate {
+				continue
+			}
+
+		}
+		rsp, err := decryptKey(key, svcs)
 		if err != nil {
 			keyErrs = append(keyErrs, err)
-		} else {
+		}
+		if rsp != nil {
+			part = rsp
+		}
+	}
+	if part != nil {
+		if len(keyErrs) == 0 {
 			return part, nil
 		}
+		return part, decryptKeyErrors(keyErrs)
 	}
 	return nil, decryptKeyErrors(keyErrs)
 }
@@ -522,7 +551,7 @@ func decryptKey(key keys.MasterKey, svcs []keyservice.KeyServiceClient) ([]byte,
 func (m Metadata) GetDataKey() ([]byte, error) {
 	return m.GetDataKeyWithKeyServices([]keyservice.KeyServiceClient{
 		keyservice.NewLocalClient(),
-	})
+	}, nil)
 }
 
 // ToBytes converts a string, int, float or bool to a byte representation.


### PR DESCRIPTION
In certain circumstances you may wish to validate that all KMS keys
are able to correctly decrypt a secret.
This enables the passing of a boolean parameter which does this.